### PR TITLE
fix: Wait few secondes before API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Whether to remove unneccessary documentation and examples from the solr director
 
 By default, this role will manage the `solr` service, ensuring it is enabled at system boot and is running. You can ensure Solr is stopped by setting `solr_service_state: stopped`, or you can disable this role's management of the `solr` service entirely by setting `solr_service_manage: false`. You may also want to set `solr_restart_handler_enabled: false` (documented later) in this case.
 
+    solr_service_wait_after_start: 5
+
+By default this role will wait 5 secondes before configuring cores to ensure that http call to get list of solr call can be answered. You can wait an other amount of seconds by setting `solr_service_wait_after_start: '10'` depending of the speed of your system.
+
     solr_install_dir: /opt
     solr_install_path: /opt/solr
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ solr_remove_cruft: false
 solr_service_manage: true
 solr_service_name: solr
 solr_service_state: started
+solr_service_wait_after_start: '5'
 
 solr_install_dir: /opt
 solr_install_path: "/opt/{{ solr_service_name }}"

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -1,7 +1,7 @@
 ---
 - name: Pause for 5 secondes to ensure that solr is really started
   ansible.builtin.pause:
-    seconds: 5
+    seconds: "{{ solr_service_wait_after_start }}"
 
 - name: Check current list of Solr cores.
   ansible.builtin.uri:

--- a/tasks/cores.yml
+++ b/tasks/cores.yml
@@ -1,13 +1,17 @@
 ---
+- name: Pause for 5 secondes to ensure that solr is really started
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Check current list of Solr cores.
-  uri:
+  ansible.builtin.uri:
     url: http://{{ solr_jetty_host if solr_jetty_host != '0.0.0.0' else solr_admin_listen_ip }}:{{ solr_port }}/solr/admin/cores
     return_content: true
   register: solr_cores_current
   check_mode: false
 
 - name: Ensure Solr conf directories exist.
-  file:
+  ansible.builtin.file:
     path: "{{ solr_home }}/data/{{ item }}/conf"
     state: directory
     owner: "{{ solr_user }}"
@@ -18,7 +22,7 @@
   with_items: "{{ solr_cores }}"
 
 - name: Ensure core configuration directories exist.
-  command: "cp -r {{ solr_default_core_path }} {{ solr_home }}/data/{{ item }}/"
+  ansible.builtin.command: "cp -r {{ solr_default_core_path }} {{ solr_home }}/data/{{ item }}/"
   when: "item not in solr_cores_current.content"
   with_items: "{{ solr_cores }}"
   become: true
@@ -27,7 +31,7 @@
 - name: Create configured cores.
   environment:
     - SOLR_HOST: "{{ solr_jetty_host if solr_jetty_host != '0.0.0.0' else solr_admin_listen_ip }}"
-  command: >
+  ansible.builtin.command: >
     {{ solr_install_path }}/bin/solr create
     -c {{ item }}
     -p {{ solr_port }}


### PR DESCRIPTION
Solr is not fully available after en restart:
```
$ curl http://127.0.0.1:8983/solr/admin/cores
{
  "responseHeader":{
    "status":0,
    "QTime":10
  },
  "initFailures":{ },
  "status":{
    "CoreName":{
      "name":"CoreName",
    }
  }
}
$ sudo systemctl restart solr.service  ; curl http://127.0.0.1:8983/solr/admin/cores
{
  "responseHeader":{
    "status":0,
    "QTime":8
  },
  "initFailures":{ },
  "status":{ }
}
$ sudo systemctl restart solr.service  ; sleep 5s ;  curl http://127.0.0.1:8983/solr/admin/cores
{
  "responseHeader":{
    "status":0,
    "QTime":10
  },
  "initFailures":{ },
  "status":{
    "CoreName":{
      "name":"CoreName",
    }
  }
}
```
